### PR TITLE
fix unit tests

### DIFF
--- a/classes/rest/o365api.php
+++ b/classes/rest/o365api.php
@@ -238,6 +238,9 @@ abstract class o365api {
         }
 
         $result = $this->httpclient->$httpmethod($requesturi, $params, $options);
+        if ($this->httpclient->info === null) {
+            return $result;
+        }
         if ($this->httpclient->info['http_code'] == 429) {
             // We are being throttled.
             $ratelimitlevel++;

--- a/lang/en/local_o365.php
+++ b/lang/en/local_o365.php
@@ -950,3 +950,4 @@ $string['course_selector_label'] = "Select existing course";
 
 // Misc.
 $string['spsite_group_contributors_desc'] = 'All users who have access to manage files for course {$a}';
+$string ['cachedef_groups'] = 'Group cache';


### PR DESCRIPTION
Fixes

```
1) core_cache_administration_helper_testcase::test_get_summaries
Unexpected debugging() call detected.
Debugging: String does not exist. Please check your string definition for cachedef_groups/local_o365
* line 10577 of /lib/moodlelib.php: call to debugging()
* line 623 of /cache/classes/definition.php: call to lang_string->__construct()
* line 187 of /cache/classes/administration_helper.php: call to cache_definition->get_name()
* line 97 of /cache/tests/administration_helper_test.php: call to core_cache\administration_helper::get_definition_summaries()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to core_cache_administration_helper_testcase->test_get_summaries()
* line 842 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 80 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 693 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 796 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 652 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 206 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->doRun()
* line 162 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 60 of phpvfscomposer:///vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 118 of /vendor/bin/phpunit: call to include()


/var/www/site/lib/phpunit/classes/advanced_testcase.php:88
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "core_cache_administration_helper_testcase" cache/tests/administration_helper_test.php

2) local_o365_coursegroups_testcase::test_create_group
array_intersect_key(): Expected parameter 1 to be an array, bool given

/var/www/site/local/o365/tests/coursegroups_test.php:118
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "local_o365_coursegroups_testcase" local/o365/tests/coursegroups_test.php

3) local_o365_coursegroups_testcase::test_resync_group_membership
Trying to access array offset on value of type null

/var/www/site/local/o365/classes/rest/o365api.php:241
/var/www/site/local/o365/classes/rest/unified.php:147
/var/www/site/local/o365/classes/rest/unified.php:567
/var/www/site/local/o365/classes/feature/usergroups/coursegroups.php:700
/var/www/site/local/o365/classes/feature/usergroups/coursegroups.php:543
/var/www/site/local/o365/tests/coursegroups_test.php:210
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "local_o365_coursegroups_testcase" local/o365/tests/coursegroups_test.php

4) local_o365_usersync_testcase::test_sync_users_create
Trying to access array offset on value of type null

/var/www/site/local/o365/classes/rest/o365api.php:241
/var/www/site/local/o365/classes/rest/unified.php:147
/var/www/site/local/o365/classes/rest/unified.php:828
/var/www/site/local/o365/tests/usersync_test.php:305
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "local_o365_usersync_testcase" local/o365/tests/usersync_test.php
````