### PR TITLE
Fix external_format_value not found issue

### DIFF
--- a/classes/webservices/read_assignments.php
+++ b/classes/webservices/read_assignments.php
@@ -28,16 +28,17 @@ namespace local_o365\webservices;
 use assign;
 use context_course;
 use context_module;
-use external_api;
-use external_function_parameters;
-use external_multiple_structure;
-use external_single_structure;
-use external_value;
-use external_warnings;
 use moodle_exception;
-use moodle_url;
 
 defined('MOODLE_INTERNAL') || die();
+
+use core_external\external_api;
+use core_external\external_function_parameters;
+use core_external\external_multiple_structure;
+use core_external\external_single_structure;
+use core_external\external_value;
+use core_external\external_warnings;
+use moodle_url;
 
 global $CFG;
 

--- a/classes/webservices/read_assignments.php
+++ b/classes/webservices/read_assignments.php
@@ -32,12 +32,13 @@ use moodle_exception;
 
 defined('MOODLE_INTERNAL') || die();
 
-use core_external\external_api;
-use core_external\external_function_parameters;
-use core_external\external_multiple_structure;
-use core_external\external_single_structure;
-use core_external\external_value;
-use core_external\external_warnings;
+use external_api;
+use external_format_value;
+use external_function_parameters;
+use external_multiple_structure;
+use external_single_structure;
+use external_value;
+use external_warnings;
 use moodle_url;
 
 global $CFG;

--- a/classes/webservices/read_assignments.php
+++ b/classes/webservices/read_assignments.php
@@ -28,9 +28,6 @@ namespace local_o365\webservices;
 use assign;
 use context_course;
 use context_module;
-use moodle_exception;
-
-defined('MOODLE_INTERNAL') || die();
 
 use external_api;
 use external_format_value;
@@ -39,7 +36,10 @@ use external_multiple_structure;
 use external_single_structure;
 use external_value;
 use external_warnings;
+use moodle_exception;
 use moodle_url;
+
+defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 


### PR DESCRIPTION
```
1) core\externallib_test::test_all_external_info with data set "local_o365_get_assignments" (stdClass Object (...))
Error: Class 'local_o365\webservices\external_format_value' not found
```
It's doing this without importing external_format_value from the correct namespace.

Since Moodle 4.x moved many core classes (like external_format_value) under core_external